### PR TITLE
ci: enable gradle build cache

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+          cache: gradle
       ###
       - uses: DeLaGuardo/setup-graalvm@5.0
         if: inputs.build_on_graal


### PR DESCRIPTION
See See https://github.com/actions/setup-java#caching-packages-dependencies and https://github.com/openrewrite/rewrite/pull/2938