### PR TITLE
Also allow moderneinc repos to use `ci-gradle.yml`

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -66,7 +66,10 @@ jobs:
           arguments: ${{ env.GRADLE_SWITCHES }} build
 
       - name: publish-snapshots
-        if: inputs.publish_snapshots && github.event_name != 'pull_request' && github.repository_owner == 'openrewrite'
+        if: >
+          inputs.publish_snapshots &&
+          github.event_name != 'pull_request' &&
+          (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: gradle/gradle-build-action@v2
         with:
           arguments: ${{ env.GRADLE_SWITCHES }} snapshot publish -PforceSigning -x test


### PR DESCRIPTION
Rather than copying the whole thing, also adding `moderneinc` to the list of allowed GitHub organizations for the `publish-snapshots` step.
