### PR TITLE
Automatically review PRs

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -14,11 +14,6 @@ on:
         type: boolean
         default: true
         required: false
-      publish_tests:
-        description: Whether to attempt publishing unit test results.
-        type: boolean
-        default: true
-        required: false
     secrets:
       gradle_enterprise_access_key:
         description: Value of the Gradle Enterprise access token to use.

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -17,8 +17,6 @@ on:
 jobs:
   post-suggestions:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     env:
       # Used by https://github.com/googleapis/code-suggester?tab=readme-ov-file#review-a-pull-request
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -1,0 +1,59 @@
+---
+name: comment-pr
+
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+on:
+  workflow_call:
+    secrets:
+      GH_PAT_ACTIONS_READ:
+        required: true
+        description: |
+          A GitHub PAT with `actions:read` permissions on the target repo.
+          This is used to download the patch and the PR number from the triggering workflow.
+          See https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
+
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# Since this pull request has write permissions on the target repo, we should **NOT** execute any untrusted code.
+jobs:
+  post-suggestions:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      # Used by https://github.com/googleapis/code-suggester?tab=readme-ov-file#review-a-pull-request
+      ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.workflow_run.head_branch}}
+          repository: ${{github.event.workflow_run.head_repository.full_name}}
+
+      # Download the patch
+      - uses: actions/download-artifact@v4
+        with:
+          name: patch
+          github-token: ${{ secrets.GH_PAT_ACTIONS_READ }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Apply patch
+        run: |
+          git apply git-diff.patch --allow-empty
+          rm git-diff.patch
+
+      # Download the PR number
+      - uses: actions/download-artifact@v4
+        with:
+          name: pr_number
+          github-token: ${{ secrets.GH_PAT_ACTIONS_READ }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Read pr_number.txt
+        run: |
+          PR_NUMBER=$(cat pr_number.txt)
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          rm pr_number.txt
+
+      # Post suggestions as a comment on the PR
+      - uses: googleapis/code-suggester@v2
+        with:
+          command: review
+          pull_number: ${{ env.PR_NUMBER }}
+          git_dir: '.'

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -26,7 +26,7 @@ jobs:
 
       # Apply license headers and capture the diff
       - name: Check licenses
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: ${{ env.GRADLE_SWITCHES }} licenseFormat
 

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -1,0 +1,46 @@
+---
+name: receive-pr
+
+on:
+  workflow_call:
+
+env:
+  GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# Since this pull request receives untrusted code, we should **NOT** have any secrets in the environment.
+jobs:
+  upload-patch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: 'gradle'
+
+      # Apply license headers and capture the diff
+      - name: Check licenses
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ${{ env.GRADLE_SWITCHES }} licenseFormat
+
+      - name: Create patch
+        run: git diff > git-diff.patch
+      - uses: actions/upload-artifact@v4
+        with:
+          name: patch
+          path: git-diff.patch
+
+      # Capture the PR number
+      - name: Create pr_number.txt
+        run: echo "${{ github.event.number }}" > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt


### PR DESCRIPTION
## What's changed?
Add two workflows that together automatically add code suggestions on opened pull requests.

## What's your motivation?
Keep up with community contributions more easily, by suggesting code changes to conform to our best practices.

## Any additional context
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- https://github.com/googleapis/code-suggester?tab=readme-ov-file#review-a-pull-request
- https://github.com/timtebeek/code-suggester-action-reproducer
- https://docs.openrewrite.org/recipes/java/recipes