### PR TITLE
Revise GitHub Actions for Gradle

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           fetch-depth: 0
           show-progress: false
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v3
       ########################
       - uses: actions/setup-java@v4.0.0
         with:
@@ -56,19 +56,18 @@ jobs:
           java-version: ${{ inputs.java_version }}
 
       ########################
-      - name: build
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: ${{ env.GRADLE_SWITCHES }} build
+
+      - name: build
+        run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
 
       - name: publish-snapshots
         if: >
           inputs.publish_snapshots &&
           github.event_name != 'pull_request' &&
           (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: ${{ env.GRADLE_SWITCHES }} snapshot publish -PforceSigning -x test
+        run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot publish -PforceSigning -x test
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ossrh_username }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ossrh_token }}

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -37,28 +37,29 @@ jobs:
           distribution: temurin
           java-version: 21
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: publish-candidate
         if: contains(github.ref, '-rc.')
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: |
-            ${{ env.GRADLE_SWITCHES }}
-            -Preleasing
-            -Prelease.disableGitChecks=true
-            -Prelease.useLastTag=true
-            candidate
-            publish
-            closeAndReleaseSonatypeStagingRepository
+        run: |
+          ./gradlew
+          ${{ env.GRADLE_SWITCHES }}
+          -Preleasing
+          -Prelease.disableGitChecks=true
+          -Prelease.useLastTag=true
+          candidate
+          publish
+          closeAndReleaseSonatypeStagingRepository
 
       - name: publish-release
         if: (!contains(github.ref, '-rc.'))
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: |
-            ${{ env.GRADLE_SWITCHES }}
-            -Preleasing
-            -Prelease.disableGitChecks=true
-            -Prelease.useLastTag=true
-            final
-            publish
-            closeAndReleaseSonatypeStagingRepository
+        run: |
+          ./gradlew
+          ${{ env.GRADLE_SWITCHES }}
+          -Preleasing
+          -Prelease.disableGitChecks=true
+          -Prelease.useLastTag=true
+          final
+          publish
+          closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v3
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -72,11 +72,13 @@ jobs:
       - name: Remove pr_number.txt
         run: rm -f pr_number.txt
 
+      # Setup Gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       # Apply license headers
       - name: Apply license headers
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: ${{ env.GRADLE_SWITCHES }} licenseFormat
+        run: ./gradlew ${{ env.GRADLE_SWITCHES }} licenseFormat
 
       # Execute best practices recipe
       - name: Create temporary files
@@ -84,9 +86,7 @@ jobs:
           echo "${{ inputs.rewrite_yml }}" > rewrite.yml
           echo "${{ inputs.init_gradle }}" > rewrite-init.gradle
       - name: Apply OpenRewrite best practices
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: ${{ env.GRADLE_SWITCHES }} rewriteRun --init-script rewrite-init.gradle -Drewrite.activeRecipe=${{ inputs.recipe }}
+        run: ./gradlew ${{ env.GRADLE_SWITCHES }} rewriteRun --init-script rewrite-init.gradle -Drewrite.activeRecipe=${{ inputs.recipe }}
       - name: Remove temporary files
         run: rm -f rewrite.yml rewrite-init.gradle
 


### PR DESCRIPTION
## What's changed?
- Call `gradle/actions/setup-gradle` separately from executing Gradle goals
- Adopt `gradle/actions/wrapper-validation`

## What's your motivation?
- Using the action to execute Gradle via the arguments parameter is deprecated
https://github.com/openrewrite/rewrite-github-actions/issues/100
- `gradle/wrapper-validation-action` has been deprecated and now delegates.
https://github.com/gradle/wrapper-validation-action/releases/tag/v3.3.0

## Any additional context
- https://github.com/openrewrite/rewrite-github-actions/issues/100
- https://github.com/openrewrite/rewrite-github-actions/issues/101