### PR TITLE
Updating the Sonatatype secrets

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -24,9 +24,9 @@ on:
       gradle_enterprise_cache_password:
         description: Value of the Gradle Enterprise Cache password to use.
         required: false
-      ossrh_username:
+      ossrh_username_1:
         required: false
-      ossrh_token:
+      ossrh_token_1:
         required: false
       ossrh_signing_key:
         required: false
@@ -69,7 +69,7 @@ jobs:
           (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot publish -PforceSigning -x test
         env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ossrh_username }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ossrh_token }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ossrh_username_1 }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ossrh_token_1 }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ossrh_signing_key }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ossrh_signing_password }}

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -7,9 +7,9 @@ on:
       gradle_enterprise_access_key:
         description: Value of the Gradle Enterprise access token to use.
         required: false
-      ossrh_username:
+      ossrh_username_1:
         required: true
-      ossrh_token:
+      ossrh_token_1:
         required: true
       ossrh_signing_key:
         required: true
@@ -18,8 +18,8 @@ on:
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
-  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ossrh_username }}
-  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ossrh_token }}
+  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ossrh_username_1 }}
+  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ossrh_token_1 }}
   ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ossrh_signing_key }}
   ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ossrh_signing_password }}
 


### PR DESCRIPTION
We are currently failing to authenticate with Sonatatype. I have kept all the original secrets and users if we want to roll back. I have been digging into this issue, and my only promising lead is trying to generate new permissions. I have created new tokens and uploaded them to the Github secrets. I have created new secrets in Github to avoid any destructive work. As such, I have appended the existing secret names with "_1"

I am applying this change to both the ci-gradle and publishing-gradle scripts as they are both currently failing the authentication at the moment 
