### PR TITLE
Revert updating sonatatype secrets 

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -24,9 +24,9 @@ on:
       gradle_enterprise_cache_password:
         description: Value of the Gradle Enterprise Cache password to use.
         required: false
-      ossrh_username_1:
+      ossrh_username:
         required: false
-      ossrh_token_1:
+      ossrh_token:
         required: false
       ossrh_signing_key:
         required: false
@@ -69,7 +69,7 @@ jobs:
           (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot publish -PforceSigning -x test
         env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ossrh_username_1 }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ossrh_token_1 }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ossrh_username }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ossrh_token }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ossrh_signing_key }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ossrh_signing_password }}

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -7,9 +7,9 @@ on:
       gradle_enterprise_access_key:
         description: Value of the Gradle Enterprise access token to use.
         required: false
-      ossrh_username_1:
+      ossrh_username:
         required: true
-      ossrh_token_1:
+      ossrh_token:
         required: true
       ossrh_signing_key:
         required: true
@@ -18,8 +18,8 @@ on:
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
-  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ossrh_username_1 }}
-  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ossrh_token_1 }}
+  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ossrh_username }}
+  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ossrh_token }}
   ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ossrh_signing_key }}
   ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ossrh_signing_password }}
 


### PR DESCRIPTION
This reverts commit https://github.com/openrewrite/gh-automation/commit/898b4c659c6d5199621b676aaa363fc28bc632e8.

This change was wrong and update the name of the provided secrets and not the secret pulled from github when running the associated script 