### PR TITLE
Only run PR commenter when the PR isn't in draft.

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -9,6 +9,7 @@ on:
 # Since this pull request has write permissions on the target repo, we should **NOT** execute any untrusted code.
 jobs:
   post-suggestions:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
       # GH API does not allow PAT for https://github.com/googleapis/code-suggester?tab=readme-ov-file#review-a-pull-request


### PR DESCRIPTION
## What's changed?

The PR commenter can be pretty annoying when a PR is still in draft and is being iterated on with many commits. See this example for a PR that got basically ruined by the bot: https://github.com/openrewrite/rewrite/pull/5050