### PR TITLE
Locking snapshots publishing to `main` branch builds only

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -66,6 +66,7 @@ jobs:
         if: >
           inputs.publish_snapshots &&
           github.event_name != 'pull_request' &&
+          github.ref == 'refs/heads/main' &&
           (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot publish -PforceSigning -x test
         env:


### PR DESCRIPTION
## What's changed?

Adding a safety check to CI action, so that Maven snapshots are only published when the build is from `main` branch of respective project.

## What's your motivation?

Guard against a confusing situation when someone ran CI from a modified branch and it resulted in unexpected code being published as snapshot.

## Anything in particular you'd like reviewers to focus on?

Yes. My assumption is that we universally use `main` as the main (:D) development branch, e.g. we don't use `master` or anything else.

## Testing performed

Performed the CI execution on modified branch and observed the snapshots **not** being published.