### PR TITLE
Adding stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+---
+name: stale
+
+on:
+  workflow_call:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          days-before-stale: 90
+          days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          days-before-stale: 90
-          days-before-close: 7
+          stale-pr-message: 'This PR is stale because it has been open for 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          days-before-stale: -1 # Do not close issues
+          days-before-pr-stale: 90


### PR DESCRIPTION
## What's changed?

Adding stale workflow for closing stale PRs with no activity in 90 days.

Note: this does **not** touch issues. They should stay!

## What's your motivation?

To clean-up the PR queues in our OSS projects.

## Additional context
- https://github.com/actions/stale
