### PR TITLE
Send notification on CI failures to our internal Slack

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -72,6 +72,8 @@ jobs:
           MSG_MINIMAL: actions url
           SLACK_USERNAME: ${{ github.event.repository.name }} CI failure
           SLACK_COLOR: failure
+          SLACK_MESSAGE: ''
+          SLACK_FOOTER: ''
 
       - name: publish-snapshots
         if: >

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -62,7 +62,7 @@ jobs:
       - name: build
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
 
-      - name: slackNotificationOfFailure:
+      - name: slackNotificationOfFailure
         if: failure()
         uses: rtCamp/action-slack-notify@v2.3.3
           env:

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -72,7 +72,6 @@ jobs:
           MSG_MINIMAL: actions url
           SLACK_USERNAME: ${{ github.event.repository.name }} CI failure
           SLACK_COLOR: failure
-          SLACK_MESSAGE: ''
           SLACK_FOOTER: ''
 
       - name: publish-snapshots

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: slackNotificationOfFailure
         if: failure()
-        uses: rtCamp/action-slack-notify@v2.3.3
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
         env:
           SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
 

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -32,6 +32,8 @@ on:
         required: false
       ossrh_signing_password:
         required: false
+      OPS_GITHUB_ACTIONS_WEBHOOK:
+        required: true
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -65,7 +65,7 @@ jobs:
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
 
       - name: slackNotificationOfFailure
-        if: failure()
+        if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
         env:
           SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -62,6 +62,12 @@ jobs:
       - name: build
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
 
+      - name: slackNotificationOfFailure:
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2.3.3
+          env:
+            SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+
       - name: publish-snapshots
         if: >
           inputs.publish_snapshots &&

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -65,8 +65,8 @@ jobs:
       - name: slackNotificationOfFailure
         if: failure()
         uses: rtCamp/action-slack-notify@v2.3.3
-          env:
-            SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+        env:
+          SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
 
       - name: publish-snapshots
         if: >

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -69,6 +69,9 @@ jobs:
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
         env:
           SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+          MSG_MINIMAL: actions url
+          SLACK_USERNAME: Github CI failure notification
+          SLACK_COLOR: failure
 
       - name: publish-snapshots
         if: >

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
           MSG_MINIMAL: actions url
-          SLACK_USERNAME: Github CI failure notification
+          SLACK_USERNAME: ${{ github.event.repository.name }} CI failure
           SLACK_COLOR: failure
 
       - name: publish-snapshots


### PR DESCRIPTION
## What's changed?

Adding an extra step to the CI flow.
Namely one to send a Slack notification to our internal Slack.

## What's your motivation?

Be able to follow CI failures in an easier way.

## Context

This requires changes to all projects calling `.github/workflows/ci-gradle.yml`.
So don't merge it until this is done (I can take care of it).
