### PR TITLE
Close issues with unanswered questions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,13 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-pr-message: 'This PR is stale because it has been open for 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          days-before-stale: -1 # Do not close issues
+          # When questions go unanswered for 60 days, we assume the reported has lost interest.
+          stale-issue-label: 'question'
+          stale-issue-message: 'This issue is stale because it has not had any activity for 60 days. Remove `question` label or comment or this will be closed in two weeks. Issues may be reopened when there is renewed interest.'
+          days-before-stale: 60
+          days-before-close: 14
+
+          # When PRs see no activity for 90 days, we assume the author has lost interest.
+          stale-pr-message: 'This PR is stale because it has been open for 90 days with no activity. Remove `stale` label or comment or this will be closed in two weeks. PRs may be reopened when there is renewed interest.'
           days-before-pr-stale: 90
           operations-per-run: 100


### PR DESCRIPTION
The No status column hold issues that have come in, where we asked for clarification, and sometimes then do not get any reply.
https://github.com/orgs/openrewrite/projects/4/views/10?filterQuery=label%3Aquestion

I propose we close such issues automatically rather than having to periodically review these manually to see if they are still relevant.

We may need to triage the issues with `questions` label once before we activate this automation.