### PR TITLE
Run CI on Java 25 by default

### DIFF
--- a/.github/workflows/ci-gradle-blacksmith.yml
+++ b/.github/workflows/ci-gradle-blacksmith.yml
@@ -13,7 +13,7 @@ on:
         description: Java version for setup-java
         type: string
         required: false
-        default: 21
+        default: 25
       publish_snapshots:
         description: Whether to attempt publishing snapshots. When false, the workflow will only run build.
         type: boolean

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -8,7 +8,7 @@ on:
         description: Java version for setup-java
         type: string
         required: false
-        default: 21
+        default: 25
       publish_snapshots:
         description: Whether to attempt publishing snapshots. When false, the workflow will only run build.
         type: boolean

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -8,7 +8,7 @@ on:
         description: Java version for setup-java
         type: string
         required: false
-        default: 21
+        default: 25
     secrets:
       gradle_enterprise_access_key:
         description: Value of the Gradle Enterprise access token to use.

--- a/.github/workflows/receive-pr-runner.yml
+++ b/.github/workflows/receive-pr-runner.yml
@@ -7,7 +7,7 @@ on:
         description: Java version for setup-java
         type: string
         required: false
-        default: 21
+        default: 25
       recipe_id:
         description: The OpenRewrite recipe ID to apply to the PR
         type: string


### PR DESCRIPTION
Figured since we now use the Kotlin v2 compiler, we can finally run our CI on Java 25, and move the tests over to Java 25.