### PR TITLE
Pass npm version as job output for cross-job consistency

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -14,6 +14,10 @@ on:
         type: boolean
         default: true
         required: false
+    outputs:
+      npm_version:
+        description: The npm package version determined during build
+        value: ${{ jobs.build.outputs.npm_version }}
     secrets:
       gradle_enterprise_access_key:
         description: Value of the Gradle Enterprise access token to use.
@@ -42,6 +46,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
+    outputs:
+      npm_version: ${{ steps.npm-version.outputs.npm_version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -65,6 +71,15 @@ jobs:
 
       - name: build
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
+
+      - name: extract npm version
+        id: npm-version
+        if: always()
+        run: |
+          VERSION_FILE="rewrite-javascript/src/main/resources/META-INF/rewrite-javascript-version.txt"
+          if [ -f "$VERSION_FILE" ]; then
+            echo "npm_version=$(cat "$VERSION_FILE")" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: slackNotificationOfFailure
         if: (failure() || cancelled()) && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -9,6 +9,10 @@ on:
         type: string
         required: false
         default: 21
+    outputs:
+      npm_version:
+        description: The npm package version determined during build
+        value: ${{ jobs.release.outputs.npm_version }}
     secrets:
       gradle_enterprise_access_key:
         description: Value of the Gradle Enterprise access token to use.
@@ -42,6 +46,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    outputs:
+      npm_version: ${{ steps.npm-version.outputs.npm_version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -80,3 +86,12 @@ jobs:
           final \
           publish \
           closeAndReleaseSonatypeStagingRepository
+
+      - name: extract npm version
+        id: npm-version
+        if: always()
+        run: |
+          VERSION_FILE="rewrite-javascript/src/main/resources/META-INF/rewrite-javascript-version.txt"
+          if [ -f "$VERSION_FILE" ]; then
+            echo "npm_version=$(cat "$VERSION_FILE")" >> "$GITHUB_OUTPUT"
+          fi


### PR DESCRIPTION
## Summary

- Extract the npm version from `rewrite-javascript-version.txt` after build/publish and expose it as a workflow output
- Callers (like `openrewrite/rewrite`) can pass this version to the `npm-publish` job so it publishes the correct version

**Companion PR:** openrewrite/rewrite (pending)

## Context

The npm-publish job runs in a separate workflow job with a fresh checkout, so it cannot read the version.txt file written during the build/release job. This caused release builds (e.g. `v8.75.3`) to publish the wrong npm version (e.g. `8.76.0-20260311-003608`) because Nebula computed a snapshot version without `-Prelease.useLastTag=true`.

## Test plan

- [ ] Verify snapshot CI publishes matching npm version
- [ ] Verify release publish uses the correct tag version for npm