### PR TITLE
Add uv setup to publish-gradle workflow

### DIFF
--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -52,6 +52,9 @@ jobs:
           distribution: temurin
           java-version: ${{ inputs.java_version }}
 
+      ########################
+      - uses: astral-sh/setup-uv@v7
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:


### PR DESCRIPTION
## Summary
- Add `astral-sh/setup-uv@v7` to `publish-gradle.yml`, matching what was done for `ci-gradle.yml` in a5dab900
- Repos like `rewrite-prethink` that install Python packages via pip during the Gradle build need uv available in the publish workflow too

## Context
The CI workflow was updated to include uv setup on Feb 10, but the publish workflow was missed. This causes publish failures for repos that depend on Python tooling during the build.