### PR TITLE
Don't notify Slack on cancelled scheduled runs

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -67,7 +67,7 @@ jobs:
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
 
       - name: slackNotificationOfFailure
-        if: (failure() || cancelled()) && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
         continue-on-error: true
         env:


### PR DESCRIPTION
The `slackNotificationOfFailure` step in `ci-gradle.yml` was triggering on both `failure()` and `cancelled()`. This caused spurious Slack notifications when runs were cancelled due to newer commits superseding them via concurrency groups. Removed the `cancelled()` check so only actual failures send notifications.