### PR TITLE
Link Slack CI failure notifications to the workflow run

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -72,7 +72,8 @@ jobs:
         continue-on-error: true
         env:
           SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
-          MSG_MINIMAL: actions url
+          MSG_MINIMAL: true
+          SLACK_MESSAGE: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SLACK_USERNAME: ${{ github.event.repository.name }} CI failure
           SLACK_COLOR: failure
           SLACK_FOOTER: ''


### PR DESCRIPTION
## Summary
- The Slack notification on scheduled CI failures linked to `commit/{SHA}/checks`, which shows all checks for a commit rather than the specific failing run.
- Replaced the default `actions url` field with a custom `SLACK_MESSAGE` that links directly to `actions/runs/{run_id}`, taking you straight to the failing pipeline.