### PR TITLE
Include organization in Slack CI failure username

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -74,7 +74,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
           MSG_MINIMAL: true
           SLACK_MESSAGE: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          SLACK_USERNAME: ${{ github.event.repository.name }} CI failure
+          SLACK_USERNAME: ${{ github.repository }} CI failure
           SLACK_COLOR: failure
           SLACK_FOOTER: ''
 


### PR DESCRIPTION
## Summary
- Use `github.repository` (owner/repo) instead of `github.event.repository.name` in the Slack notification username
- Disambiguates CI failure notifications for repos that exist in multiple organizations (e.g. openrewrite and moderneinc)

## Test plan
- Verify the workflow YAML is valid
- Trigger a scheduled build failure and confirm the Slack notification shows e.g. "openrewrite/rewrite CI failure"