### PR TITLE
Revert default CI Java version from 25 back to 21

### DIFF
--- a/.github/workflows/ci-gradle-blacksmith.yml
+++ b/.github/workflows/ci-gradle-blacksmith.yml
@@ -13,7 +13,7 @@ on:
         description: Java version for setup-java
         type: string
         required: false
-        default: 25
+        default: 21
       publish_snapshots:
         description: Whether to attempt publishing snapshots. When false, the workflow will only run build.
         type: boolean

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -8,7 +8,7 @@ on:
         description: Java version for setup-java
         type: string
         required: false
-        default: 25
+        default: 21
       publish_snapshots:
         description: Whether to attempt publishing snapshots. When false, the workflow will only run build.
         type: boolean

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -8,7 +8,7 @@ on:
         description: Java version for setup-java
         type: string
         required: false
-        default: 25
+        default: 21
     secrets:
       gradle_enterprise_access_key:
         description: Value of the Gradle Enterprise access token to use.

--- a/.github/workflows/receive-pr-runner.yml
+++ b/.github/workflows/receive-pr-runner.yml
@@ -7,7 +7,7 @@ on:
         description: Java version for setup-java
         type: string
         required: false
-        default: 25
+        default: 21
       recipe_id:
         description: The OpenRewrite recipe ID to apply to the PR
         type: string


### PR DESCRIPTION
- Reverts #86, which set the default `java_version` input to 25 across the reusable Gradle CI/publish/receive-pr workflows.

Restores the default to 21 in `ci-gradle.yml`, `ci-gradle-blacksmith.yml`, `publish-gradle.yml`, and `receive-pr-runner.yml`. Callers that explicitly pass `java_version: 25` are unaffected.