### PR TITLE
ci-gradle: extract composite actions for finer-grained reuse

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,19 @@
+---
+name: Run Gradle build
+description: Run `./gradlew build` with the standard CI switches.
+
+inputs:
+  switches:
+    description: Gradle command-line switches.
+    required: false
+    default: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+  tasks:
+    description: Gradle tasks to invoke.
+    required: false
+    default: build
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: ./gradlew ${{ inputs.switches }} ${{ inputs.tasks }}

--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -1,0 +1,46 @@
+---
+name: Publish snapshots
+description: |
+  Run `./gradlew snapshot publish -PforceSigning -x test` with Sonatype and
+  signing credentials wired in via Gradle project properties.
+
+inputs:
+  switches:
+    description: Gradle command-line switches.
+    required: false
+    default: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+  sonatype_username:
+    required: false
+    default: ''
+  sonatype_token:
+    required: false
+    default: ''
+  ossrh_signing_key:
+    required: false
+    default: ''
+  ossrh_signing_password:
+    required: false
+    default: ''
+  node_auth_token:
+    required: false
+    default: ''
+  pypi_token:
+    required: false
+    default: ''
+  nuget_api_key:
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: ./gradlew ${{ inputs.switches }} snapshot publish -PforceSigning -x test
+      env:
+        ORG_GRADLE_PROJECT_sonatypeUsername: ${{ inputs.sonatype_username }}
+        ORG_GRADLE_PROJECT_sonatypePassword: ${{ inputs.sonatype_token }}
+        ORG_GRADLE_PROJECT_signingKey: ${{ inputs.ossrh_signing_key }}
+        ORG_GRADLE_PROJECT_signingPassword: ${{ inputs.ossrh_signing_password }}
+        ORG_GRADLE_PROJECT_nodeAuthToken: ${{ inputs.node_auth_token }}
+        ORG_GRADLE_PROJECT_pypiToken: ${{ inputs.pypi_token }}
+        ORG_GRADLE_PROJECT_nugetApiKey: ${{ inputs.nuget_api_key }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,36 @@
+---
+name: Set up Gradle build environment
+description: |
+  Checkout the repository (full history), install the requested JDK(s), set up
+  uv, and configure Gradle with optional Develocity access. Designed to be the
+  first step a Gradle-based job takes; the build / publish composite actions
+  in this repo assume this has run.
+
+inputs:
+  java_version:
+    description: Java version(s) to install (passed verbatim to actions/setup-java).
+    required: false
+    default: '21'
+  develocity_access_key:
+    description: Develocity / Gradle Enterprise access key, if any.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        show-progress: false
+
+    - uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: ${{ inputs.java_version }}
+
+    - uses: astral-sh/setup-uv@v7
+
+    - uses: gradle/actions/setup-gradle@v5
+      with:
+        develocity-access-key: ${{ inputs.develocity_access_key }}

--- a/.github/actions/slack-failure/action.yml
+++ b/.github/actions/slack-failure/action.yml
@@ -1,0 +1,24 @@
+---
+name: Notify Slack on CI failure
+description: |
+  Post a CI-failure notification to a Slack webhook. The caller is responsible
+  for guarding this with an appropriate `if:` condition (typically
+  `failure() && github.event_name == 'schedule'`).
+
+inputs:
+  webhook:
+    description: Slack incoming webhook URL.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+      continue-on-error: true
+      env:
+        SLACK_WEBHOOK: ${{ inputs.webhook }}
+        MSG_MINIMAL: true
+        SLACK_MESSAGE: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        SLACK_USERNAME: ${{ github.repository }} CI failure
+        SLACK_COLOR: failure
+        SLACK_FOOTER: ''

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -35,61 +35,38 @@ on:
       nuget_api_key:
         required: false
 
-env:
-  GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
-
 jobs:
   build:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
     steps:
-      - uses: actions/checkout@v6
+      # Each step below is a thin call into a composite action under
+      # .github/actions/ in this repo. Consumers that need to inject custom
+      # setup (e.g. a Maven mirror) can bypass this reusable workflow and
+      # call those composite actions directly from their own job.
+      - uses: openrewrite/gh-automation/.github/actions/setup@main
         with:
-          fetch-depth: 0
-          show-progress: false
+          java_version: ${{ inputs.java_version }}
+          develocity_access_key: ${{ secrets.gradle_enterprise_access_key }}
 
-      ########################
-      - uses: actions/setup-java@v5
+      - uses: openrewrite/gh-automation/.github/actions/build@main
+
+      - if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        uses: openrewrite/gh-automation/.github/actions/slack-failure@main
         with:
-          distribution: temurin
-          java-version: ${{ inputs.java_version }}
+          webhook: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
 
-      ########################
-      - uses: astral-sh/setup-uv@v7
-
-      ########################
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-        with:
-          develocity-access-key: ${{ secrets.gradle_enterprise_access_key }}
-
-      - name: build
-        run: ./gradlew ${{ env.GRADLE_SWITCHES }} build
-
-      - name: slackNotificationOfFailure
-        if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
-        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
-        continue-on-error: true
-        env:
-          SLACK_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
-          MSG_MINIMAL: true
-          SLACK_MESSAGE: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          SLACK_USERNAME: ${{ github.repository }} CI failure
-          SLACK_COLOR: failure
-          SLACK_FOOTER: ''
-
-      - name: publish-snapshots
-        if: >
+      - if: >
           inputs.publish_snapshots &&
           github.event_name != 'pull_request' &&
           github.ref == 'refs/heads/main' &&
           (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
-        run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot publish -PforceSigning -x test
-        env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatype_username }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatype_token }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ossrh_signing_key }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ossrh_signing_password }}
-          ORG_GRADLE_PROJECT_nodeAuthToken: ${{ secrets.node_auth_token }}
-          ORG_GRADLE_PROJECT_pypiToken: ${{ secrets.pypi_token }}
-          ORG_GRADLE_PROJECT_nugetApiKey: ${{ secrets.nuget_api_key }}
+        uses: openrewrite/gh-automation/.github/actions/publish-snapshots@main
+        with:
+          sonatype_username: ${{ secrets.sonatype_username }}
+          sonatype_token: ${{ secrets.sonatype_token }}
+          ossrh_signing_key: ${{ secrets.ossrh_signing_key }}
+          ossrh_signing_password: ${{ secrets.ossrh_signing_password }}
+          node_auth_token: ${{ secrets.node_auth_token }}
+          pypi_token: ${{ secrets.pypi_token }}
+          nuget_api_key: ${{ secrets.nuget_api_key }}


### PR DESCRIPTION
## Summary
- Split the step bodies in \`ci-gradle.yml\` into four composite actions under \`.github/actions/\`: \`setup\`, \`build\`, \`slack-failure\`, \`publish-snapshots\`.
- The reusable workflow \`ci-gradle.yml\` now calls each composite action in order, so it stays the convenient one-liner for consumers that don't need finer control.
- Consumers that *do* need to inject custom setup (e.g. configuring an \`~/.m2/settings.xml\` Maven mirror to dodge Maven Central rate-limiting under parallel test load) can now bypass the reusable workflow and call the composite actions directly from their own job.

## Why
Reusable workflows can't accept "inject this step here" inputs, so every per-consumer setup need (Maven mirror, custom CA cert, custom DNS, …) became another bespoke knob on the reusable workflow. Composite actions compose with arbitrary consumer steps, which is the GitHub-Actions-idiomatic answer for that extensibility need.

## Compatibility
Existing consumers (\`uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main\`) keep working with no change — same inputs, same secrets.

Example of the new finer-grained usage:

\`\`\`yaml
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: openrewrite/gh-automation/.github/actions/setup@main
        with:
          java_version: |
            25
            21
          develocity_access_key: \${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
      - uses: s4u/maven-settings-action@v3.1.0
        with:
          mirrors: '[{"id": "moderne-cache", "name": "Moderne Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
      - uses: openrewrite/gh-automation/.github/actions/build@main
      - if: failure() && github.event_name == 'schedule'
        uses: openrewrite/gh-automation/.github/actions/slack-failure@main
        with:
          webhook: \${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
\`\`\`

## Test plan
- [ ] Reusable-workflow consumers (e.g. openrewrite/rewrite \`ci.yml\`) keep building unchanged after this merges.
- [ ] openrewrite/rewrite follow-up PR (https://github.com/openrewrite/rewrite/pull/7559) switches to the composite-action form to add the Maven mirror step; CI passes there.