### PR TITLE
Route Maven through Moderne Artifactory cache to avoid HTTP 429

### DIFF
--- a/.github/workflows/ci-gradle-blacksmith.yml
+++ b/.github/workflows/ci-gradle-blacksmith.yml
@@ -40,6 +40,18 @@ on:
         required: false
       node_auth_token:
         required: false
+      artifactory_username:
+        description: Username for artifactory.moderne.ninja, used by the Maven mirror.
+        required: false
+      artifactory_password:
+        description: Password for artifactory.moderne.ninja, used by the Maven mirror.
+        required: false
+      ast_publish_username:
+        description: Username for the Gradle mirror (REWRITE_GRADLE_MIRROR_USERNAME).
+        required: false
+      ast_publish_password:
+        description: Password for the Gradle mirror (REWRITE_GRADLE_MIRROR_PASSWORD).
+        required: false
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
@@ -69,8 +81,19 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.gradle_enterprise_access_key }}
 
+      # Route Maven resolution through Moderne's Artifactory cache to avoid
+      # Maven Central rate-limiting (HTTP 429) under parallel test load.
+      - uses: s4u/maven-settings-action@v4.0.0
+        with:
+          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
+          servers: ${{ secrets.artifactory_username != '' && format('[{{"id":"moderne-cache","username":"{0}","password":"{1}"}}]', secrets.artifactory_username, secrets.artifactory_password) || '[]' }}
+
       - name: build
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} ${{ inputs.rerun_tasks && '--rerun-tasks' || '' }} build
+        env:
+          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
+          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.ast_publish_username }}
+          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.ast_publish_password }}
 
       - name: slackNotificationOfFailure
         if: (failure() || cancelled()) && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')

--- a/.github/workflows/ci-gradle-blacksmith.yml
+++ b/.github/workflows/ci-gradle-blacksmith.yml
@@ -41,16 +41,10 @@ on:
       node_auth_token:
         required: false
       artifactory_username:
-        description: Username for artifactory.moderne.ninja, used by the Maven mirror.
+        description: Username for artifactory.moderne.ninja, used for both the Maven mirror and the Gradle mirror.
         required: false
       artifactory_password:
-        description: Password for artifactory.moderne.ninja, used by the Maven mirror.
-        required: false
-      ast_publish_username:
-        description: Username for the Gradle mirror (REWRITE_GRADLE_MIRROR_USERNAME).
-        required: false
-      ast_publish_password:
-        description: Password for the Gradle mirror (REWRITE_GRADLE_MIRROR_PASSWORD).
+        description: Password for artifactory.moderne.ninja, used for both the Maven mirror and the Gradle mirror.
         required: false
 
 env:
@@ -92,8 +86,8 @@ jobs:
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} ${{ inputs.rerun_tasks && '--rerun-tasks' || '' }} build
         env:
           REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
-          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.ast_publish_username }}
-          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.ast_publish_password }}
+          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.artifactory_username }}
+          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.artifactory_password }}
 
       - name: slackNotificationOfFailure
         if: (failure() || cancelled()) && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -34,22 +34,41 @@ on:
         required: false
       nuget_api_key:
         required: false
+      artifactory_username:
+        description: Username for artifactory.moderne.ninja, used by the Maven mirror.
+        required: false
+      artifactory_password:
+        description: Password for artifactory.moderne.ninja, used by the Maven mirror.
+        required: false
+      ast_publish_username:
+        description: Username for the Gradle mirror (REWRITE_GRADLE_MIRROR_USERNAME).
+        required: false
+      ast_publish_password:
+        description: Password for the Gradle mirror (REWRITE_GRADLE_MIRROR_PASSWORD).
+        required: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
     steps:
-      # Each step below is a thin call into a composite action under
-      # .github/actions/ in this repo. Consumers that need to inject custom
-      # setup (e.g. a Maven mirror) can bypass this reusable workflow and
-      # call those composite actions directly from their own job.
       - uses: openrewrite/gh-automation/.github/actions/setup@main
         with:
           java_version: ${{ inputs.java_version }}
           develocity_access_key: ${{ secrets.gradle_enterprise_access_key }}
 
+      # Route Maven resolution through Moderne's Artifactory cache to avoid
+      # Maven Central rate-limiting (HTTP 429) under parallel test load.
+      - uses: s4u/maven-settings-action@v4.0.0
+        with:
+          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
+          servers: ${{ secrets.artifactory_username != '' && format('[{{"id":"moderne-cache","username":"{0}","password":"{1}"}}]', secrets.artifactory_username, secrets.artifactory_password) || '[]' }}
+
       - uses: openrewrite/gh-automation/.github/actions/build@main
+        env:
+          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
+          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.ast_publish_username }}
+          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.ast_publish_password }}
 
       - if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: openrewrite/gh-automation/.github/actions/slack-failure@main

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -35,16 +35,10 @@ on:
       nuget_api_key:
         required: false
       artifactory_username:
-        description: Username for artifactory.moderne.ninja, used by the Maven mirror.
+        description: Username for artifactory.moderne.ninja, used for both the Maven mirror and the Gradle mirror.
         required: false
       artifactory_password:
-        description: Password for artifactory.moderne.ninja, used by the Maven mirror.
-        required: false
-      ast_publish_username:
-        description: Username for the Gradle mirror (REWRITE_GRADLE_MIRROR_USERNAME).
-        required: false
-      ast_publish_password:
-        description: Password for the Gradle mirror (REWRITE_GRADLE_MIRROR_PASSWORD).
+        description: Password for artifactory.moderne.ninja, used for both the Maven mirror and the Gradle mirror.
         required: false
 
 jobs:
@@ -67,8 +61,8 @@ jobs:
       - uses: openrewrite/gh-automation/.github/actions/build@main
         env:
           REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
-          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.ast_publish_username }}
-          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.ast_publish_password }}
+          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.artifactory_username }}
+          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.artifactory_password }}
 
       - if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: openrewrite/gh-automation/.github/actions/slack-failure@main

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -28,16 +28,10 @@ on:
       nuget_api_key:
         required: false
       artifactory_username:
-        description: Username for artifactory.moderne.ninja, used by the Maven mirror.
+        description: Username for artifactory.moderne.ninja, used for both the Maven mirror and the Gradle mirror.
         required: false
       artifactory_password:
-        description: Password for artifactory.moderne.ninja, used by the Maven mirror.
-        required: false
-      ast_publish_username:
-        description: Username for the Gradle mirror (REWRITE_GRADLE_MIRROR_USERNAME).
-        required: false
-      ast_publish_password:
-        description: Password for the Gradle mirror (REWRITE_GRADLE_MIRROR_PASSWORD).
+        description: Password for artifactory.moderne.ninja, used for both the Maven mirror and the Gradle mirror.
         required: false
 
 env:
@@ -50,8 +44,8 @@ env:
   ORG_GRADLE_PROJECT_pypiToken: ${{ secrets.pypi_token }}
   ORG_GRADLE_PROJECT_nugetApiKey: ${{ secrets.nuget_api_key }}
   REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
-  REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.ast_publish_username }}
-  REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.ast_publish_password }}
+  REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.artifactory_username }}
+  REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.artifactory_password }}
 
 jobs:
   release:

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -27,6 +27,18 @@ on:
         required: false
       nuget_api_key:
         required: false
+      artifactory_username:
+        description: Username for artifactory.moderne.ninja, used by the Maven mirror.
+        required: false
+      artifactory_password:
+        description: Password for artifactory.moderne.ninja, used by the Maven mirror.
+        required: false
+      ast_publish_username:
+        description: Username for the Gradle mirror (REWRITE_GRADLE_MIRROR_USERNAME).
+        required: false
+      ast_publish_password:
+        description: Password for the Gradle mirror (REWRITE_GRADLE_MIRROR_PASSWORD).
+        required: false
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
@@ -37,6 +49,9 @@ env:
   ORG_GRADLE_PROJECT_nodeAuthToken: ${{ secrets.node_auth_token }}
   ORG_GRADLE_PROJECT_pypiToken: ${{ secrets.pypi_token }}
   ORG_GRADLE_PROJECT_nugetApiKey: ${{ secrets.nuget_api_key }}
+  REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
+  REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.ast_publish_username }}
+  REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.ast_publish_password }}
 
 jobs:
   release:
@@ -58,6 +73,13 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
         with:
           develocity-access-key: ${{ secrets.gradle_enterprise_access_key }}
+
+      # Route Maven resolution through Moderne's Artifactory cache to avoid
+      # Maven Central rate-limiting (HTTP 429) under parallel test load.
+      - uses: s4u/maven-settings-action@v4.0.0
+        with:
+          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
+          servers: ${{ secrets.artifactory_username != '' && format('[{{"id":"moderne-cache","username":"{0}","password":"{1}"}}]', secrets.artifactory_username, secrets.artifactory_password) || '[]' }}
 
       - name: publish-candidate
         if: contains(github.ref, '-rc.')


### PR DESCRIPTION
## Summary
- Maven Central started rate-limiting parallel test resolution (`HTTP 429`), failing CI on many consumers of these reusable workflows (rewrite-dropwizard, rewrite-spring, rewrite-spring-to-quarkus, rewrite-jenkins, rewrite-java-dependencies, rewrite-migrate-java, rewrite-spring, rewrite-micronaut, rewrite-quarkus, rewrite-jackson, …).
- Adds the mirror configuration that `moderneinc/rewrite-java-security` has been running inline for a while: route `mirrorOf: \"*\"` through `https://artifactory.moderne.ninja/artifactory/moderne-cache-3/` via `s4u/maven-settings-action`, and set `REWRITE_GRADLE_MIRROR_*` env vars on the Gradle build/publish steps so rewrite-core's test-time resolution also goes through the cache.
- Applied to `ci-gradle.yml`, `ci-gradle-blacksmith.yml`, and `publish-gradle.yml`.
- The new secrets (`artifactory_username`/`_password`, `ast_publish_username`/`_password`) are optional; when unset the mirror is consulted anonymously, which is sufficient for any artifact present in the anonymous-readable backing repos of `moderne-cache-3`.

## Validated
Inline rollout earlier today across nine recipe repos, five of which were merged and went green via this exact config:
- moderneinc/rewrite-dropwizard#14
- openrewrite/rewrite-spring-to-quarkus#85
- openrewrite/rewrite-spring#1016
- openrewrite/rewrite-micronaut#139
- openrewrite/rewrite-quarkus#112

## Follow-up
Once merged, the per-repo workflows that were patched inline should revert to the thin-caller form (single \`uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main\`) and pick up the mirror automatically. I'll open the revert PRs.

A handful of consumers (rewrite-jenkins, rewrite-java-dependencies, rewrite-jackson, rewrite-migrate-java) failed earlier with HTTP 401 from the mirror — an Artifactory virtual-repo iteration quirk where auth-gated backing repos shadow anonymously-readable ones. That's a server-side config issue in \`moderne-cache-3\` and doesn't affect the correctness of this PR; it does mean those four repos will continue to fail until the backing-repo order is fixed.

## Test plan
- [ ] CI on this PR passes
- [ ] After merge, trigger CI on one consumer repo (e.g. \`gh workflow run ci.yml -R openrewrite/rewrite-quarkus\`) and confirm the mirror config is applied and no \`HTTP 429\` appears