### PR TITLE
Use --refresh-dependencies for snapshot publishes

### DIFF
--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -1,8 +1,12 @@
 ---
 name: Publish snapshots
 description: |
-  Run `./gradlew snapshot publish -PforceSigning -x test` with Sonatype and
-  signing credentials wired in via Gradle project properties.
+  Run `./gradlew --refresh-dependencies snapshot publish -PforceSigning -x test`
+  with Sonatype and signing credentials wired in via Gradle project properties.
+  `--refresh-dependencies` is required to clear Gradle's module-to-repository
+  cache; without it Gradle can keep resolving `latest.integration` against
+  Maven Central only (skipping the Sonatype snapshot repo) once a stale mapping
+  has been restored via gradle/actions cache fallback.
 
 inputs:
   switches:
@@ -35,7 +39,7 @@ runs:
   using: composite
   steps:
     - shell: bash
-      run: ./gradlew ${{ inputs.switches }} snapshot publish -PforceSigning -x test
+      run: ./gradlew ${{ inputs.switches }} --refresh-dependencies snapshot publish -PforceSigning -x test
       env:
         ORG_GRADLE_PROJECT_sonatypeUsername: ${{ inputs.sonatype_username }}
         ORG_GRADLE_PROJECT_sonatypePassword: ${{ inputs.sonatype_token }}


### PR DESCRIPTION
## Summary
- Adds `--refresh-dependencies` to the `./gradlew snapshot publish` command in `publish-snapshots/action.yml`.
- Forces Gradle to re-discover which repository each module lives in on every snapshot publish, instead of trusting a possibly-stale `modules-2/metadata-2.X/` mapping restored from a previous run.

## Why

For weeks, the `moderne-recipe-bom` BOM-alignment check has been failing because several recipe SNAPSHOTs (`rewrite-ai-search`, `rewrite-circleci`, `rewrite-codemods-ng`, `rewrite-concourse`, `rewrite-dotnet`, `rewrite-kubernetes`, `rewrite-sql`) were pinning `org.openrewrite:rewrite-bom:8.82.1` (the latest *released* line) instead of `8.83.0-SNAPSHOT`. Their `build.gradle.kts` correctly uses `latest.integration` via `rewriteRecipe.rewriteVersion`, and the convention plugin correctly declares the Sonatype snapshots repo — but in CI, Gradle was only querying Maven Central for `rewrite-bom`'s `maven-metadata.xml`, never the snapshot repo.

### Root cause (proven by experiment)

Gradle keeps a persistent **module-to-repository mapping cache** in `~/.gradle/caches/modules-2/metadata-2.X/`. Once a module is resolved from a specific repo, Gradle records that and short-circuits future dynamic-version lookups to only query the recorded repo. `cacheDynamicVersionsFor(0)` re-validates *which version* is latest, but not *which repository* contains the module.

That mapping was seeded weeks ago when `rewrite-bom 8.83.0-SNAPSHOT` did not yet exist (so `rewrite-bom` was only on Maven Central). It's been restored across CI runs by `gradle/actions/setup-gradle@v5` — even after deleting exact cache keys, `restore-keys` fall back to older entries.

I proved this by running the same `latest.integration` resolution on the same code with only one change: adding `gradle.startParameter.isRefreshDependencies = true` to `settings.gradle.kts`. With it, Gradle queries the snapshot repo and resolves `rewrite-bom → 8.83.0-SNAPSHOT`; without it, it only queries Maven Central and resolves to `8.82.1`. See run [26182077433](https://github.com/moderneinc/rewrite-ai-search/actions/runs/26182077433) (resolves correctly) vs [26181369276](https://github.com/moderneinc/rewrite-ai-search/actions/runs/26181369276) (vanilla, broken).

## Tradeoffs
- Adds ~10–30s per snapshot publish for metadata re-download.
- Bandwidth/load on Maven Central + Sonatype goes up slightly, but `--refresh-dependencies` does conditional GETs (HTTP `If-Modified-Since`), so most fetches return 304.

## Test plan
- [ ] Merge.
- [ ] Trigger a snapshot publish on one of the affected repos (e.g. `moderneinc/rewrite-ai-search`) and confirm its new snapshot POM pins `rewrite-bom:8.83.0-SNAPSHOT`.
- [ ] Re-run `moderneinc/moderne-recipe-bom` CI and confirm `:checkBomAlignment` passes.