### PR TITLE
(optionally) Upload NPM published version as an artifact

### DIFF
--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -48,3 +48,13 @@ runs:
         ORG_GRADLE_PROJECT_nodeAuthToken: ${{ inputs.node_auth_token }}
         ORG_GRADLE_PROJECT_pypiToken: ${{ inputs.pypi_token }}
         ORG_GRADLE_PROJECT_nugetApiKey: ${{ inputs.nuget_api_key }}
+
+    # A build may record the exact snapshot version of an artifact it just deployed
+    # (e.g. rewrite-javascript writes build/npm/publishedVersion.txt) so a decoupled
+    # downstream publisher can mirror it. Generic and a no-op when no such file exists.
+    - uses: actions/upload-artifact@v4
+      with:
+        name: published-snapshot-version
+        path: '**/build/npm/publishedVersion.txt'
+        if-no-files-found: ignore
+        retention-days: 7


### PR DESCRIPTION
## What's changed?

Publish the NPM version string as an GHA artifact of the build.
Obvioiusly, only if it exists.

## What's your motivation?

As one of the steps towards synchronizing the version numbering between rewrite-javascript Maven artifact and NPM artifact.
Currently it's not in sync at times for **snapshots** (proper release versions are fine)