### PR TITLE
Upgrade official GitHub Actions to their latest versions

### DIFF
--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -52,7 +52,7 @@ runs:
     # A build may record the exact snapshot version of an artifact it just deployed
     # (e.g. rewrite-javascript writes build/npm/publishedVersion.txt) so a decoupled
     # downstream publisher can mirror it. Generic and a no-op when no such file exists.
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: published-snapshot-version
         path: '**/build/npm/publishedVersion.txt'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
         show-progress: false


### PR DESCRIPTION
Applied the `org.openrewrite.github.UpgradeOfficialGitHubActions` recipe from [rewrite-github-actions](https://github.com/openrewrite/rewrite-github-actions), which upgrades actions from the official `actions` and `github` organizations to the newest known version (offline, preserving each reference's existing precision).

## Changes

Both remaining upgrades were in composite action definitions (`action.yml`), which the recipe now matches via `IsGitHubActionDefinition`:

- `.github/actions/setup/action.yml`: `actions/checkout@v6` → `@v7`
- `.github/actions/publish-snapshots/action.yml`: `actions/upload-artifact@v4` → `@v7`

All other official action references (`@v7`, `setup-java@v5`, `download-artifact@v8`, `stale@v10`, etc.) were already at the newest known major version and left untouched.