### PR TITLE
Export CGP AWS credentials for publishing to the Code Genome Project

### DIFF
--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -34,6 +34,14 @@ inputs:
   nuget_api_key:
     required: false
     default: ''
+  cgp_aws_access_key_id:
+    description: AWS access key id for publishing snapshots to the Code Genome Project.
+    required: false
+    default: ''
+  cgp_aws_secret_access_key:
+    description: AWS secret access key for publishing snapshots to the Code Genome Project.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -48,6 +56,11 @@ runs:
         ORG_GRADLE_PROJECT_nodeAuthToken: ${{ inputs.node_auth_token }}
         ORG_GRADLE_PROJECT_pypiToken: ${{ inputs.pypi_token }}
         ORG_GRADLE_PROJECT_nugetApiKey: ${{ inputs.nuget_api_key }}
+        # Publish snapshots to the Code Genome Project. Empty when a repo has not forwarded the
+        # secret, which leaves the org.openrewrite.build.publish-cgp convention plugin inert.
+        AWS_ACCESS_KEY_ID: ${{ inputs.cgp_aws_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.cgp_aws_secret_access_key }}
+        AWS_REGION: us-west-2
 
     # A build may record the exact snapshot version of an artifact it just deployed
     # (e.g. rewrite-javascript writes build/npm/publishedVersion.txt) so a decoupled

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -40,6 +40,10 @@ on:
       artifactory_password:
         description: Password for artifactory.moderne.ninja, used for both the Maven mirror and the Gradle mirror.
         required: false
+      cgp_aws_access_key_id:
+        required: false
+      cgp_aws_secret_access_key:
+        required: false
 
 jobs:
   build:
@@ -83,3 +87,5 @@ jobs:
           node_auth_token: ${{ secrets.node_auth_token }}
           pypi_token: ${{ secrets.pypi_token }}
           nuget_api_key: ${{ secrets.nuget_api_key }}
+          cgp_aws_access_key_id: ${{ secrets.cgp_aws_access_key_id }}
+          cgp_aws_secret_access_key: ${{ secrets.cgp_aws_secret_access_key }}

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -33,6 +33,12 @@ on:
       artifactory_password:
         description: Password for artifactory.moderne.ninja, used for both the Maven mirror and the Gradle mirror.
         required: false
+      cgp_aws_access_key_id:
+        description: AWS access key id for publishing artifacts to the Code Genome Project.
+        required: false
+      cgp_aws_secret_access_key:
+        description: AWS secret access key for publishing artifacts to the Code Genome Project.
+        required: false
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
@@ -46,6 +52,11 @@ env:
   REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
   REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.artifactory_username }}
   REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.artifactory_password }}
+  # Publish releases to the Code Genome Project. Empty when a repo has not forwarded the
+  # secret, which leaves the org.openrewrite.build.publish-cgp convention plugin inert.
+  AWS_ACCESS_KEY_ID: ${{ secrets.cgp_aws_access_key_id }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.cgp_aws_secret_access_key }}
+  AWS_REGION: us-west-2
 
 jobs:
   release:


### PR DESCRIPTION
Wires optional `cgp_aws_access_key_id` / `cgp_aws_secret_access_key` secrets into the shared Gradle publish flows and exports them as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION=us-west-2`:

- **`publish-gradle.yml`** (releases) — workflow-level env, so the aggregate `publish` task picks them up.
- **`publish-snapshots` action** (snapshots) — env on the `snapshot publish` step; forwarded from **`ci-gradle.yml`**.

This lets the new `org.openrewrite.build.publish-cgp` convention plugin (in `rewrite-build-gradle-plugin`, applied via `recipe-library`) publish recipe artifacts to the Code Genome Project S3 repository — releases and unique/timestamped snapshots. Maven Central publishing continues for now and will be retired separately once CGP is the source of record.

### Safe, gradual rollout
The plugin activates **only when `AWS_ACCESS_KEY_ID` is non-empty**. A repo that has not forwarded the `CGP_AWS_*` org secrets gets empty values here, so the plugin stays completely inert — no behavior change until a repo opts in.

### Rollout checklist (outside this PR)
- [x] `CGP_AWS_ACCESS_KEY_ID` / `CGP_AWS_SECRET_ACCESS_KEY` org secrets set in `openrewrite` and `moderneinc` (visibility: all).
- [ ] Release a `rewrite-build-gradle-plugin` version containing the `publish-cgp` convention plugin (repos float `latest.release`, so they pick it up automatically).
- [ ] Forward the secrets from each recipe repo's caller `publish.yml` / `ci.yml`:
  ```yaml
        cgp_aws_access_key_id: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
        cgp_aws_secret_access_key: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
  ```

The publisher IAM key is scoped to `s3:PutObject`/`GetObject`/`PutObjectTagging` on `codegenome-artifacts/oss/*` only.
