### PR TITLE
Publish snapshots to the Code Genome Project via an injected init script

### DIFF
--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -8,6 +8,9 @@ description: |
   Maven Central only (skipping the Sonatype snapshot repo) once a stale mapping
   has been restored via gradle/actions cache fallback.
 
+  When the CGP AWS credentials are forwarded, an injected init script also publishes
+  each snapshot to the Code Genome Project's S3-backed Maven repo.
+
 inputs:
   switches:
     description: Gradle command-line switches.
@@ -47,7 +50,14 @@ runs:
   using: composite
   steps:
     - shell: bash
-      run: ./gradlew ${{ inputs.switches }} --refresh-dependencies snapshot publish -PforceSigning -x test
+      # --init-script adds the Code Genome Project S3 repo as a second publish target (inert
+      # without the CGP creds); the s3.endpoint override points Gradle at the bucket's region so
+      # snapshot PUTs sign correctly instead of 301-ing off the us-east-1 global endpoint.
+      run: >
+        ./gradlew ${{ inputs.switches }}
+        --refresh-dependencies snapshot publish -PforceSigning -x test
+        --init-script "${{ github.action_path }}/cgp-publish.init.gradle"
+        -Dorg.gradle.s3.endpoint=https://s3.us-west-2.amazonaws.com
       env:
         ORG_GRADLE_PROJECT_sonatypeUsername: ${{ inputs.sonatype_username }}
         ORG_GRADLE_PROJECT_sonatypePassword: ${{ inputs.sonatype_token }}
@@ -56,8 +66,8 @@ runs:
         ORG_GRADLE_PROJECT_nodeAuthToken: ${{ inputs.node_auth_token }}
         ORG_GRADLE_PROJECT_pypiToken: ${{ inputs.pypi_token }}
         ORG_GRADLE_PROJECT_nugetApiKey: ${{ inputs.nuget_api_key }}
-        # Publish snapshots to the Code Genome Project. Empty when a repo has not forwarded the
-        # secret, which leaves the org.openrewrite.build.publish-cgp convention plugin inert.
+        # Read by cgp-publish.init.gradle to authenticate the Code Genome Project S3 repo. Empty
+        # when a repo has not forwarded the secret, which leaves that init script inert.
         AWS_ACCESS_KEY_ID: ${{ inputs.cgp_aws_access_key_id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.cgp_aws_secret_access_key }}
         AWS_REGION: us-west-2

--- a/.github/actions/publish-snapshots/cgp-publish.init.gradle
+++ b/.github/actions/publish-snapshots/cgp-publish.init.gradle
@@ -1,0 +1,26 @@
+// Injected via --init-script by the publish-snapshots action so a repo's `publish` also pushes
+// to the Code Genome Project's S3-backed Maven repo. Inert unless the CGP AWS credentials reached
+// this build — they are absent on forks and on repos that never forwarded the org secret.
+import org.gradle.api.credentials.AwsCredentials
+
+def cgpAccessKey = System.getenv("AWS_ACCESS_KEY_ID")
+def cgpSecretKey = System.getenv("AWS_SECRET_ACCESS_KEY")
+
+if (cgpAccessKey && cgpSecretKey) {
+    gradle.allprojects { project ->
+        project.pluginManager.withPlugin("maven-publish") {
+            project.publishing {
+                repositories {
+                    maven {
+                        name = "codeGenomeProject"
+                        url = "s3://codegenome-artifacts/maven"
+                        credentials(AwsCredentials) {
+                            accessKey = cgpAccessKey
+                            secretKey = cgpSecretKey
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

- Completes the Code Genome Project (CGP) snapshot dual-publish. #99 exported the CGP AWS credentials onto the `snapshot publish` step, but nothing consumed them — the convention plugin that was meant to declare the S3 repo never existed, so the credentials sat unused and no snapshots reached CGP.

This adds the missing link:

- **`cgp-publish.init.gradle`** — passed to the publish invocation via `--init-script`. When the `AWS_*` env is present, it registers `s3://codegenome-artifacts/maven` as a second `maven-publish` repository on every project, so `publish` pushes there alongside Sonatype. It self-gates on the credentials, so it's a no-op on forks and on repos that never forwarded the org secret.
- **`-Dorg.gradle.s3.endpoint=https://s3.us-west-2.amazonaws.com`** — points Gradle's built-in S3 transport at the bucket's region so snapshot PUTs sign correctly instead of 301-ing off the us-east-1 global endpoint (Gradle's S3 transport doesn't read `AWS_REGION`).

## Rollout / blast radius

Backward-compatible everywhere: inert unless a repo forwards `cgp_aws_*` (which reaches the reusable workflow's `AWS_*` env). Repos on `secrets: inherit` start dual-publishing once this merges; explicit-`secrets:` repos additionally need the two-line `cgp_aws_*` forward (rewrite already has it).

## Verification

First live signal will be rewrite's next `main` push: watch the `publish…ToCodeGenomeProjectRepository` tasks succeed against the bucket.