### PR TITLE
Silence AWS SDK for Java 1.x deprecation banner on CGP publish

### DIFF
--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -61,6 +61,10 @@ runs:
         AWS_ACCESS_KEY_ID: ${{ inputs.cgp_aws_access_key_id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.cgp_aws_secret_access_key }}
         AWS_REGION: us-west-2
+        # Gradle's own s3:// transport still bundles AWS SDK for Java 1.x, which prints a
+        # deprecation banner with a stack trace on every upload. Drop once Gradle ships
+        # https://github.com/gradle/gradle/pull/29686 (milestone 9.8.0).
+        AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT: true
 
     # A build may record the exact snapshot version of an artifact it just deployed
     # (e.g. rewrite-javascript writes build/npm/publishedVersion.txt) so a decoupled

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -57,6 +57,10 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.cgp_aws_access_key_id }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.cgp_aws_secret_access_key }}
   AWS_REGION: us-west-2
+  # Gradle's own s3:// transport still bundles AWS SDK for Java 1.x, which prints a
+  # deprecation banner with a stack trace on every upload. Drop once Gradle ships
+  # https://github.com/gradle/gradle/pull/29686 (milestone 9.8.0).
+  AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT: true
 
 jobs:
   release:


### PR DESCRIPTION
Publishing to the Code Genome Project goes over Gradle's built-in `s3://` repository transport, which still bundles AWS SDK for Java 1.x. Every upload therefore prints a multi-line deprecation announcement with a stack trace, e.g. [this jsonrpc snapshot publish](https://github.com/moderneinc/jsonrpc/actions/runs/30533546363/job/90841262998#step:7:923):

```
The AWS SDK for Java 1.x entered maintenance mode starting July 31, 2024 and will reach end of support on December 31, 2025.
...
at org.gradle.internal.resource.transport.aws.s3.S3Client.createConnectionProperties(S3Client.java:102)
at org.gradle.api.publish.maven.internal.publisher.MavenRemotePublisher.publish(MavenRemotePublisher.java:63)
```

- Nothing on our side declares that SDK, so there's no upgrade available: Gradle's migration to `aws-sdk-java-v2` is https://github.com/gradle/gradle/pull/29686, still open and milestoned for 9.8.0. Until that ships, set `AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT` alongside the existing CGP AWS credentials so the banner stays out of publish logs. Added in both places that publish to CGP — the release workflow and the snapshot action — with a comment pointing at the Gradle PR to remove it again.