### PR TITLE
Export CGP artifact repository credentials for dependency resolution

### DIFF
--- a/.github/workflows/ci-gradle-blacksmith.yml
+++ b/.github/workflows/ci-gradle-blacksmith.yml
@@ -46,9 +46,19 @@ on:
       artifactory_password:
         description: Password for artifactory.moderne.ninja, used for both the Maven mirror and the Gradle mirror.
         required: false
+      cgp_artifacts_maven_username:
+        description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty when a
+  # repo has not forwarded the secret, which leaves the recipe-repositories convention plugin inert.
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 
 jobs:
   build:

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -44,6 +44,18 @@ on:
         required: false
       cgp_aws_secret_access_key:
         required: false
+      cgp_artifacts_maven_username:
+        description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+
+# Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty when a
+# repo has not forwarded the secret, which leaves the recipe-repositories convention plugin inert.
+env:
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 
 jobs:
   build:

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -39,6 +39,12 @@ on:
       cgp_aws_secret_access_key:
         description: AWS secret access key for publishing artifacts to the Code Genome Project.
         required: false
+      cgp_artifacts_maven_username:
+        description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
@@ -61,6 +67,10 @@ env:
   # deprecation banner with a stack trace on every upload. Drop once Gradle ships
   # https://github.com/gradle/gradle/pull/29686 (milestone 9.8.0).
   AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT: true
+  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty when a
+  # repo has not forwarded the secret, which leaves the recipe-repositories convention plugin inert.
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 
 jobs:
   release:


### PR DESCRIPTION
Wires the new org-level `CGP_ARTIFACTS_MAVEN_USERNAME` / `CGP_ARTIFACTS_MAVEN_TOKEN` secrets into the shared Gradle workflows as optional `cgp_artifacts_maven_username` / `cgp_artifacts_maven_token` inputs, exported as `ORG_GRADLE_PROJECT_codegenomeUsername` / `ORG_GRADLE_PROJECT_codegenomePassword`.

That's what `org.openrewrite.build.recipe-repositories` reads in openrewrite/rewrite-build-gradle-plugin@ae519d96d4c648c0cffe15c16a2a0387a18a9834 to add https://artifacts.codegenomeproject.org/maven as a group-scoped repository for `org.openrewrite` and `io.moderne`.

- `ci-gradle.yml`, `ci-gradle-blacksmith.yml`, `publish-gradle.yml`: declared as optional secrets and set at the workflow level, so both the build and the snapshot/release publish resolve through it.
- The plugin only registers the repository when both values are non-empty, so repos that haven't forwarded the secrets — and pull requests from forks, where secrets are unavailable — resolve from Maven Central exactly as before.

Follow-up: downstream repos pass secrets explicitly rather than with `secrets: inherit`, so each caller's `ci.yml` / `publish.yml` still needs

```yaml
      cgp_artifacts_maven_username: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
      cgp_artifacts_maven_token: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
```