### PR TITLE
Enable the Gradle build cache in the shared build actions

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -6,7 +6,7 @@ inputs:
   switches:
     description: Gradle command-line switches.
     required: false
-    default: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+    default: --console=plain --info --stacktrace --warning-mode=all --no-daemon --build-cache
   tasks:
     description: Gradle tasks to invoke.
     required: false

--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -12,7 +12,7 @@ inputs:
   switches:
     description: Gradle command-line switches.
     required: false
-    default: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+    default: --console=plain --info --stacktrace --warning-mode=all --no-daemon --build-cache
   sonatype_username:
     required: false
     default: ''


### PR DESCRIPTION
Recipe repos configure a Develocity remote build cache in `settings.gradle.kts`, and `ci-gradle.yml` forwards `gradle_enterprise_access_key` — but whether task output caching is actually *on* depends on each repo setting `org.gradle.caching=true` in its own `gradle.properties`. That is currently a coin flip across the fleet, so half the consumers get a remote cache that never does anything:

```
Caching disabled for task ':compileJava' because:
  Build cache is disabled
```

This adds `--build-cache` to the default switches of `.github/actions/build` and `.github/actions/publish-snapshots`, making the behaviour uniform instead of per-repo.

## Fleet coverage

Of the 36 non-archived `openrewrite` repos that consume this shared workflow:

| | count | effect of this PR |
| --- | --- | --- |
| already set `org.gradle.caching=true` | **18** | no-op — caching is already on |
| do not set it | **18** | caching switched on for the first time |

So this is not "turning the cache on for everyone" — it's closing the gap for the half that never had it, and levelling the two groups. For an already-caching repo like [`rewrite-github-actions`](https://github.com/openrewrite/rewrite-github-actions/blob/main/gradle.properties), the flag changes nothing measurable: its latest run already restores `:compileJava`, `:compileTestJava`, `:test` and `:javadoc` `FROM-CACHE`.

(One marginal difference: the CLI flag applies from process start, the property does not, so `--build-cache` also caches init-script compilation. Worth milliseconds — not a reason to do this.)

## Validation

Ran end to end on `rewrite-cucumber-jvm` — one of the 18 *without* caching — via a throwaway canary PR (now closed), pointing at a `gh-automation` branch carrying this change with the composite-action refs pinned to itself. That pinning is necessary because `ci-gradle.yml` pins its inner `actions/build@main`, so pinning only the reusable-workflow ref would have resolved back to `main` and tested nothing.

Its pre-change run (`30948432111`) reports `Build cache is disabled` **39** times. Baseline `actions/build` over the 11 most recent runs on the current `main` workflow: mean **80s**, range **66–93s**.

| canary run | `actions/build` | `FROM-CACHE` | remote cache |
| --- | --- | --- | --- |
| 1 (cold — seeds the cache) | 58s | 0 | stored 4 entries |
| 2 (rerun, same commit) | **34s** | **4** | loaded 4 entries |

Both `success`. Run 2 restored `:compileJava`, `:compileTestJava`, `:test` and `:javadoc` with `Loaded cache entry for task ...` against `community.develocity.cloud`, confirming the remote path works and `isPush` is satisfied on CI. Post-change, `Build cache is disabled` appears **zero** times; eleven tasks remain uncached, but each for a task-specific reason (`Not worth caching`, `Caching has not been enabled for the task`, the two `recipeCsvValidate*` validation tasks).

`actionlint` clean (two pre-existing shellcheck warnings in untouched files). No repo in `openrewrite` or `moderneinc` passes an explicit `switches:` to these actions, so nobody silently loses the rest of the default set.

## Honest ceiling

Don't read 80s → 34s as the expected saving:

- Run 2 is a rerun of an identical commit — the best case. A PR touching Java sources re-executes `:compileJava` and `:test` regardless.
- Run 1 hit 58s with **zero** cache hits, below the baseline minimum of 66s, so run-to-run spread is wide enough that a single delta isn't attributable to caching.
- It only moves the needle for 18 of 36 consumers; for the rest it is a no-op.

Recipe repos pin dependencies with `latest.release` / `7.+`, so every new rewrite release changes the classpath fingerprint and invalidates entries. The wins concentrate on re-runs after a rebase, nightly builds, and the second Gradle invocation on `main` pushes. The durable claim is the hit set: on the repos that lacked it, four previously uncacheable tasks now cache, and they're the expensive ones (`:test` alone is 30s of the 72s build). Configuration time (13s) is untouched — that needs the configuration cache, a separate and riskier change.

## Deliberately not changed

- **`--refresh-dependencies` in `publish-snapshots`** — a large part of that step, but the action's header documents why it's required: without it Gradle can keep resolving `latest.integration` against Maven Central only, skipping the Sonatype snapshot repo, once a stale module-to-repository mapping is restored from the `gradle/actions` cache.
- **`fetch-depth: 0`** — needed for version inference from git history, and cheap here.
- **Test parallelism** — `RewriteJavaPlugin` already sets `maxParallelForks = availableProcessors` when `CI` is set.
- **`ci-gradle-blacksmith.yml`** — inlines its own `GRADLE_SWITCHES`, so it does *not* pick this up. Same one-line change would apply; left out to keep the blast radius to the actions actually measured.

Cross-commit hit rates under `latest.release` churn only show up once this is live. I'll watch `rewrite-cucumber-jvm` after merge and revert promptly if anything breaks.
