### PR TITLE
Cancel CI still running on closed pull requests

### DIFF
--- a/.github/workflows/cancel-pr-runs.yml
+++ b/.github/workflows/cancel-pr-runs.yml
@@ -1,0 +1,37 @@
+---
+name: cancel-pr-runs
+
+on:
+  workflow_call:
+
+# GitHub does not cancel workflow runs when a pull request is closed, so a build started on the last
+# push keeps occupying runners long after the merge. @see https://github.com/orgs/community/discussions/178882
+# Callers trigger this on `pull_request: types: [closed]`; it cancels every run still going for the
+# head commit, across all workflows, and skips itself.
+jobs:
+  cancel-pr-runs:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          runs=$(for event in pull_request pull_request_target; do
+            for status in queued in_progress; do
+              gh api --paginate \
+                "repos/$GH_REPO/actions/runs?event=$event&status=$status&head_sha=$HEAD_SHA" \
+                --jq '.workflow_runs[] | "\(.id) \(.name)"'
+            done
+          done | sort -u)
+
+          echo "$runs" | while read -r id name; do
+            if [ -z "$id" ] || [ "$id" = "$RUN_ID" ]; then
+              continue
+            fi
+            echo "Cancelling $name ($id)"
+            gh api --silent --method POST "repos/$GH_REPO/actions/runs/$id/cancel" || true
+          done

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Reusable workflows: entire jobs that another repository calls with `uses:` from 
 | `publish-gradle.yml` | Release publishing from a tag: `candidate` for `-rc.` tags, `final` otherwise, closing and releasing the Sonatype staging repository. |
 | `receive-pr-runner.yml` | Runs a Moderne CLI recipe against an incoming pull request and uploads the resulting diff as an artifact. Handles untrusted code, so it gets no secrets. |
 | `comment-pr-runner.yml` | Picks up that artifact from a `workflow_run` and posts the diff back as pull request review suggestions. Has write permissions, so it must not execute untrusted code. |
+| `cancel-pr-runs.yml` | Cancels workflow runs still in flight for a pull request once it is closed or merged. |
 | `repository-backup.yml` | Mirrors the repository to an S3-compatible object storage bucket. |
 | `stale.yml` | Closes unanswered `question` issues and pull requests without activity for 90 days. |
 
@@ -47,3 +48,20 @@ jobs:
     uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
     secrets: inherit
 ```
+
+Merging a pull request does not stop the CI run started by its last push, so add a second workflow to
+stop paying for builds whose result no longer matters:
+
+```yaml
+name: cancel-pr-runs
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  cancel:
+    uses: openrewrite/gh-automation/.github/workflows/cancel-pr-runs.yml@main
+```
+
+This covers every workflow running for that pull request, not just the one it is paired with. Add
+`permissions: actions: write` to the calling job in repositories where the default `GITHUB_TOKEN`
+permissions are read-only.


### PR DESCRIPTION
GitHub does not cancel in-flight workflow runs when a pull request is merged, so the build started by the last push keeps occupying runners after the merge button is clicked ([community discussion](https://github.com/orgs/community/discussions/178882)).

Adds a `cancel-pr-runs` reusable workflow that downstream repositories trigger on `pull_request: types: [closed]`. It cancels every queued or in-progress `pull_request`/`pull_request_target` run for the pull request head commit, across all workflows, skipping its own run.

Downstream wiring (documented in the README):

```yaml
name: cancel-pr-runs
on:
  pull_request:
    types: [closed]
jobs:
  cancel:
    uses: openrewrite/gh-automation/.github/workflows/cancel-pr-runs.yml@main
```