### PR TITLE
Refresh dependencies on the Gradle release publish path

### DIFF
--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -52,7 +52,7 @@ on:
         required: false
 
 env:
-  GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+  GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon --refresh-dependencies
   ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatype_username }}
   ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatype_token }}
   ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ossrh_signing_key }}


### PR DESCRIPTION
## The failure

The `rewrite-spring` v6.37.1 release publish [failed](https://github.com/openrewrite/rewrite-spring/actions/runs/32192538586) at `:signNebulaPublication`:

```
Cannot call Task.setEnabled(boolean) on task ':release' after task has started execution.
  at nebula.plugin.release.OverrideStrategies$ReleaseLastTagStrategy.selector(OverrideStrategies.groovy:63)
```

## Root cause

Not a nebula bug we need to work around — a *stale dependency resolution* bug in this workflow.

- Consumer repos declare `id("org.openrewrite.build.recipe-library") version "latest.release"`.
- rewrite-build-gradle-plugin **2.22.0** pins nebula release **21.0.1**, which has this regression. [**2.22.1**](https://github.com/openrewrite/rewrite-build-gradle-plugin/releases/tag/v2.22.1) pins **21.0.0** and fixes it.
- `gradle/actions/setup-gradle@v5` restores the `gradle-dependencies-v1-*` / `gradle-home-v1|...` caches written by the last `ci` run on `main`. Those carry Gradle's dynamic-version resolutions, and `cacheDynamicVersionsFor` defaults to **24 hours** — so `latest.release` stayed pinned to 2.22.0 well after 2.22.1 shipped.

Timeline (UTC):

| when | what |
|---|---|
| 08-18 10:31 | 2.22.0 released |
| 08-18 20:36:39 | `gradle-dependencies-v1-3cb344f7…` created by `ci` on `main` — caches `latest.release → 2.22.0` |
| 08-18 23:11 | 2.22.1 released |
| 08-19 07:34:10 | publish job restores that cache → resolves 2.22.0 → fails |

Deleting all 53 `gradle-*` Actions caches on rewrite-spring made the re-run resolve 2.22.1 / nebula 21.0.0 and publish cleanly. That was a manual one-off; this PR is the durable fix.

Ruled out: Develocity (task-output cache only, not dependency resolution) and the `moderne-cache-3` Artifactory mirror (`REWRITE_GRADLE_MIRROR_USERNAME`/`PASSWORD` resolve empty on public repos, and consumer repos have no `pluginManagement` block, so plugin resolution goes straight to the Gradle Plugin Portal).

## The fix, and why this option

Add `--refresh-dependencies` to `GRADLE_SWITCHES` in `publish-gradle.yml`.

The alternative considered was disabling the Gradle cache for the publish job (`cache-disabled: true`). Both eliminate the staleness, but `--refresh-dependencies` is the cheaper instrument: it invalidates cached *metadata and dynamic-version resolutions* while leaving the artifact cache intact, so most fetches become HTTP 304 revalidations rather than full redownloads. Disabling the cache throws away the artifacts too — every release would redownload its whole dependency graph, which is slow and re-exposes us to the Maven Central 429s the `moderne-cache-3` mirror exists to avoid.

- It also matches precedent already in this repo: `.github/actions/publish-snapshots/action.yml` has carried `--refresh-dependencies` since #96 for the same class of bug (a stale module-to-repository mapping making `latest.integration` resolve against Maven Central only). Release publishes now behave like snapshot publishes.

Because it lives in `GRADLE_SWITCHES`, it covers both the `publish-candidate` (`-rc.`) and `publish-release` jobs.

## Tradeoff

`--refresh-dependencies` refreshes *changing* modules too, not just dynamic versions. A release build that still resolves anything snapshot-shaped will pick up the newest snapshot available at publish time rather than the copy CI validated — so a release can be cut against a slightly newer upstream state than the last green build saw. That is the correct bias for a release: resolving against the current published world is the point, and the failure above is exactly what the opposite bias costs. There is also a modest wall-clock cost per release from re-checking metadata against every configured repository.

## Scope

Deliberately publish-only:

- `ci-gradle.yml` is left cached. Staleness there is cheap — a slightly old plugin in a CI build is a non-event — and refreshing on every push across every openrewrite repo would be expensive. Its snapshot-publish step already refreshes via the `publish-snapshots` action.
- `comment-pr-runner.yml`, `receive-pr-runner.yml`, `repository-backup.yml` and `stale.yml` run no Gradle and set up no Gradle cache, so they have no publish-time exposure to this bug.

## Blast radius

This workflow is consumed via `@main` by many openrewrite repos, so the change takes effect for every one of them the moment this merges — the next release publish in each repo will refresh dependencies. That is the intent, and the downside is bounded to the extra metadata revalidation described above, but it is not a staged rollout.
