### PR TITLE
Rename the Code Genome Project artifact secrets to CODEGENOME_USERNAME/TOKEN

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -51,18 +51,24 @@ on:
           Code Genome Project token carrying the `publish` entitlement, used by the npm/PyPI/NuGet
           publish tasks. Unrelated to the AWS keys above, which drive the Maven publish only.
         required: false
-      cgp_artifacts_maven_username:
+      CODEGENOME_USERNAME:
         description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
         required: false
-      cgp_artifacts_maven_token:
+      CODEGENOME_TOKEN:
         description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_username:
+        description: Deprecated alias for CODEGENOME_USERNAME; drop once all callers have migrated.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Deprecated alias for CODEGENOME_TOKEN; drop once all callers have migrated.
         required: false
 
 # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty when a
 # repo has not forwarded the secret, which leaves the recipe-repositories convention plugin inert.
 env:
-  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
-  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
 
 jobs:
   build:

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -44,11 +44,17 @@ on:
           Code Genome Project token carrying the `publish` entitlement, used by the npm/PyPI/NuGet
           publish tasks. Unrelated to the AWS keys above, which drive the Maven publish only.
         required: false
-      cgp_artifacts_maven_username:
+      CODEGENOME_USERNAME:
         description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
         required: false
-      cgp_artifacts_maven_token:
+      CODEGENOME_TOKEN:
         description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_username:
+        description: Deprecated alias for CODEGENOME_USERNAME; drop once all callers have migrated.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Deprecated alias for CODEGENOME_TOKEN; drop once all callers have migrated.
         required: false
 
 env:
@@ -78,8 +84,8 @@ env:
   AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT: true
   # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty when a
   # repo has not forwarded the secret, which leaves the recipe-repositories convention plugin inert.
-  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
-  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
 
 jobs:
   release:


### PR DESCRIPTION
Renames the `cgp_artifacts_maven_username`/`cgp_artifacts_maven_token` secrets to `CODEGENOME_USERNAME`/`CODEGENOME_TOKEN` in the `ci-gradle` and `publish-gradle` reusable workflows.

The old names remain declared as deprecated aliases, and each `ORG_GRADLE_PROJECT_codegenome*` binding falls back to them, so consumers can migrate at their own pace with no window where resolution breaks. Callers using `secrets: inherit` need no change at all beyond renaming the org secret; callers that map secrets explicitly can rename the two keys whenever convenient. Once every consumer is updated, `grep -rn cgp_artifacts_maven` finds the four blocks to delete.