### PR TITLE
Drop the deprecated cgp_artifacts_maven_* secret aliases

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -57,18 +57,12 @@ on:
       CODEGENOME_TOKEN:
         description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
         required: false
-      cgp_artifacts_maven_username:
-        description: Deprecated alias for CODEGENOME_USERNAME; drop once all callers have migrated.
-        required: false
-      cgp_artifacts_maven_token:
-        description: Deprecated alias for CODEGENOME_TOKEN; drop once all callers have migrated.
-        required: false
 
 # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty when a
 # repo has not forwarded the secret, which leaves the recipe-repositories convention plugin inert.
 env:
-  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
-  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN }}
 
 jobs:
   build:

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -50,12 +50,6 @@ on:
       CODEGENOME_TOKEN:
         description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
         required: false
-      cgp_artifacts_maven_username:
-        description: Deprecated alias for CODEGENOME_USERNAME; drop once all callers have migrated.
-        required: false
-      cgp_artifacts_maven_token:
-        description: Deprecated alias for CODEGENOME_TOKEN; drop once all callers have migrated.
-        required: false
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon --refresh-dependencies
@@ -84,8 +78,8 @@ env:
   AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT: true
   # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty when a
   # repo has not forwarded the secret, which leaves the recipe-repositories convention plugin inert.
-  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
-  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN }}
 
 jobs:
   release:


### PR DESCRIPTION
- Follow-up to #109, which renamed these secrets to `CODEGENOME_USERNAME`/`CODEGENOME_TOKEN` and kept `cgp_artifacts_maven_username`/`cgp_artifacts_maven_token` as deprecated aliases. This removes the aliases and the `||` fallbacks, leaving each `ORG_GRADLE_PROJECT_codegenome*` binding reading the new name only.

**Draft on purpose — downstream consumers must be migrated first.** Any caller still passing the old names silently ends up with empty credentials rather than a build error: the recipe-repositories convention plugin just goes inert and dependency resolution falls back to Maven Central, so CI stays green while CGP-only artifacts quietly stop resolving. Before marking this ready, sweep the consuming repositories for `cgp_artifacts_maven` and confirm zero hits, then delete the old `CGP_ARTIFACTS_MAVEN_*` org secrets.