### PR TITLE
Allow callers of ci-gradle to select the runner

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -4,6 +4,14 @@ name: ci-gradle
 on:
   workflow_call:
     inputs:
+      runs_on:
+        description: >
+          Runner label for the build job. Defaults to the free standard runner; override with an
+          organization larger-runner label to trade GitHub Actions spend for wall clock time.
+          Larger runners are billed per minute even on public repositories.
+        type: string
+        required: false
+        default: ubuntu-latest
       java_version:
         description: Java version for setup-java
         type: string
@@ -66,7 +74,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on }}
     if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
     steps:
       - uses: openrewrite/gh-automation/.github/actions/setup@main


### PR DESCRIPTION
## What

Adds a `runs_on` string input to `ci-gradle.yml`, defaulting to `ubuntu-latest`.

```yaml
      runs_on:
        type: string
        required: false
        default: ubuntu-latest
```
```yaml
  build:
    runs-on: ${{ inputs.runs_on }}
```

**This is a no-op for all 35 repositories that currently call this workflow.** The default keeps everyone on the free standard runner; nothing changes until a repository explicitly passes `runs_on`.

## Why

`rewrite-migrate-java` CI is bounded almost entirely by test wall clock. On a representative build (9m47s total), `:test` was 8m09s — every other task combined is ~1.5 min, so nothing outside `:test` is worth optimizing.

The blocker is core count. `RewriteJavaPlugin` sets `maxParallelForks = availableProcessors()`, and `ubuntu-latest` is 4 vCPU. Worth knowing if you ever try to tune this from the build script: **`maxParallelForks` is silently capped by `org.gradle.workers.max`**, which itself defaults to the core count, so you cannot oversubscribe forks from `tasks.test { }` alone. Gradle says so directly:

```
:test.maxParallelForks (21) is larger than max-workers (2), forcing it to 2
```

Raising the core count lifts both limits at once and needs no build-script change anywhere.

## Cost, because this one is not free

Larger runners are billed per minute **even on public repositories**, and included minutes do not apply:

> "Larger runners are always charged for, even when used by public repositories or when you have quota available from your plan."

Measured for `rewrite-migrate-java`: 100 completed `ci.yml` runs in the last 30 days, 641 minutes total. That is currently $0.00. On an 8-core runner it becomes roughly **$8.50–14/month** (x64, $0.022/min) or **$5.40–9/month** (arm64, $0.014/min).

That is per repository. Across all 35 callers it would reach the low hundreds per month, which is exactly why the default here stays `ubuntu-latest` and each repository opts in deliberately.

## Prerequisite

There is no built-in `ubuntu-latest-8-cores` label. An org owner has to create the runner in organization settings and choose its name, which becomes the `runs-on` label (GitHub's own example is `ubuntu-24.04-16core`). Until that exists there is nothing valid to pass, so this input is groundwork rather than an immediate switch.

## Caveat on the expected win

The projected ~40% reduction is extrapolated from 24m16s of total executor time redistributed over 8 forks plus ~1m40s of fixed overhead. **I have not measured an 8-core run.** Separately, two runs of the same 4-fork configuration produced `:test` times of 8m09s and 10m07s purely on which fork drew the slow classes, so run-to-run variance is ±2 min. Any evaluation of this should take a median of several runs rather than trusting one.

Refs: [Actions runner pricing](https://docs.github.com/en/billing/reference/actions-runner-pricing) · [About billing for GitHub Actions](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions) · [Managing larger runners](https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners/manage-larger-runners)