### PR TITLE
Stop requiring the Sonatype secrets now that we publish to CGP by default

### DIFF
--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -13,18 +13,6 @@ inputs:
     description: Gradle command-line switches.
     required: false
     default: --console=plain --info --stacktrace --warning-mode=all --no-daemon
-  sonatype_username:
-    required: false
-    default: ''
-  sonatype_token:
-    required: false
-    default: ''
-  ossrh_signing_key:
-    required: false
-    default: ''
-  ossrh_signing_password:
-    required: false
-    default: ''
   node_auth_token:
     required: false
     default: ''
@@ -55,10 +43,6 @@ runs:
     - shell: bash
       run: ./gradlew ${{ inputs.switches }} --refresh-dependencies snapshot publish -PforceSigning -x test
       env:
-        ORG_GRADLE_PROJECT_sonatypeUsername: ${{ inputs.sonatype_username }}
-        ORG_GRADLE_PROJECT_sonatypePassword: ${{ inputs.sonatype_token }}
-        ORG_GRADLE_PROJECT_signingKey: ${{ inputs.ossrh_signing_key }}
-        ORG_GRADLE_PROJECT_signingPassword: ${{ inputs.ossrh_signing_password }}
         ORG_GRADLE_PROJECT_nodeAuthToken: ${{ inputs.node_auth_token }}
         ORG_GRADLE_PROJECT_pypiToken: ${{ inputs.pypi_token }}
         ORG_GRADLE_PROJECT_nugetApiKey: ${{ inputs.nuget_api_key }}

--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -1,8 +1,8 @@
 ---
 name: Publish snapshots
 description: |
-  Run `./gradlew --refresh-dependencies snapshot publish -x test` with signing
-  credentials wired in via Gradle project properties.
+  Run `./gradlew --refresh-dependencies snapshot publish -x test` with the
+  publishing credentials wired in via Gradle project properties.
   `--refresh-dependencies` is required to clear Gradle's module-to-repository
   cache; without it Gradle can keep resolving `latest.integration` against
   Maven Central only (skipping the snapshot repository) once a stale mapping
@@ -13,6 +13,16 @@ inputs:
     description: Gradle command-line switches.
     required: false
     default: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+
+  # TODO Unused by the default publishing path, but kept wired until 2026-09-08: a repository that
+  # applies the deprecated org.openrewrite.build.publish-maven-central plugin to reach Central in an
+  # emergency also publishes its snapshots there, and would fail to authenticate without these.
+  sonatype_username:
+    required: false
+    default: ''
+  sonatype_token:
+    required: false
+    default: ''
 
   # TODO Drop once org.openrewrite.build.publish stops applying the signing plugin; until then
   # RewritePublishPlugin still signs the nebula publication, and an empty key fails the sign tasks
@@ -54,6 +64,8 @@ runs:
     - shell: bash
       run: ./gradlew ${{ inputs.switches }} --refresh-dependencies snapshot publish -x test
       env:
+        ORG_GRADLE_PROJECT_sonatypeUsername: ${{ inputs.sonatype_username }}
+        ORG_GRADLE_PROJECT_sonatypePassword: ${{ inputs.sonatype_token }}
         ORG_GRADLE_PROJECT_signingKey: ${{ inputs.ossrh_signing_key }}
         ORG_GRADLE_PROJECT_signingPassword: ${{ inputs.ossrh_signing_password }}
         ORG_GRADLE_PROJECT_nodeAuthToken: ${{ inputs.node_auth_token }}

--- a/.github/actions/publish-snapshots/action.yml
+++ b/.github/actions/publish-snapshots/action.yml
@@ -1,11 +1,11 @@
 ---
 name: Publish snapshots
 description: |
-  Run `./gradlew --refresh-dependencies snapshot publish -PforceSigning -x test`
-  with Sonatype and signing credentials wired in via Gradle project properties.
+  Run `./gradlew --refresh-dependencies snapshot publish -x test` with signing
+  credentials wired in via Gradle project properties.
   `--refresh-dependencies` is required to clear Gradle's module-to-repository
   cache; without it Gradle can keep resolving `latest.integration` against
-  Maven Central only (skipping the Sonatype snapshot repo) once a stale mapping
+  Maven Central only (skipping the snapshot repository) once a stale mapping
   has been restored via gradle/actions cache fallback.
 
 inputs:
@@ -13,6 +13,17 @@ inputs:
     description: Gradle command-line switches.
     required: false
     default: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+
+  # TODO Drop once org.openrewrite.build.publish stops applying the signing plugin; until then
+  # RewritePublishPlugin still signs the nebula publication, and an empty key fails the sign tasks
+  # outright on releases. See the follow-ups on openrewrite/rewrite-build-gradle-plugin#220.
+  ossrh_signing_key:
+    required: false
+    default: ''
+  ossrh_signing_password:
+    required: false
+    default: ''
+
   node_auth_token:
     required: false
     default: ''
@@ -41,8 +52,10 @@ runs:
   using: composite
   steps:
     - shell: bash
-      run: ./gradlew ${{ inputs.switches }} --refresh-dependencies snapshot publish -PforceSigning -x test
+      run: ./gradlew ${{ inputs.switches }} --refresh-dependencies snapshot publish -x test
       env:
+        ORG_GRADLE_PROJECT_signingKey: ${{ inputs.ossrh_signing_key }}
+        ORG_GRADLE_PROJECT_signingPassword: ${{ inputs.ossrh_signing_password }}
         ORG_GRADLE_PROJECT_nodeAuthToken: ${{ inputs.node_auth_token }}
         ORG_GRADLE_PROJECT_pypiToken: ${{ inputs.pypi_token }}
         ORG_GRADLE_PROJECT_nugetApiKey: ${{ inputs.nuget_api_key }}

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -32,6 +32,9 @@ on:
         required: false
       sonatype_token:
         required: false
+
+      # TODO Still used. Drop once org.openrewrite.build.publish stops applying the signing plugin,
+      # then remove after dropping the last caller. See openrewrite/rewrite-build-gradle-plugin#220.
       ossrh_signing_key:
         required: false
       ossrh_signing_password:
@@ -110,6 +113,8 @@ jobs:
           (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: openrewrite/gh-automation/.github/actions/publish-snapshots@main
         with:
+          ossrh_signing_key: ${{ secrets.ossrh_signing_key }}
+          ossrh_signing_password: ${{ secrets.ossrh_signing_password }}
           node_auth_token: ${{ secrets.node_auth_token }}
           pypi_token: ${{ secrets.pypi_token }}
           nuget_api_key: ${{ secrets.nuget_api_key }}

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -26,6 +26,8 @@ on:
       gradle_enterprise_access_key:
         description: Value of the Gradle Enterprise access token to use.
         required: false
+
+      # TODO Unused; remove after dropping the last caller
       sonatype_username:
         required: false
       sonatype_token:
@@ -34,6 +36,7 @@ on:
         required: false
       ossrh_signing_password:
         required: false
+
       OPS_GITHUB_ACTIONS_WEBHOOK:
         required: false
       node_auth_token:

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -27,7 +27,9 @@ on:
         description: Value of the Gradle Enterprise access token to use.
         required: false
 
-      # TODO Unused; remove after dropping the last caller
+      # TODO Unused by the default publishing path, but kept wired until 2026-09-08 to keep the
+      # deprecated org.openrewrite.build.publish-maven-central escape hatch usable; see the note in
+      # publish-gradle.yml. Remove then, and remove the secrets after dropping the last caller.
       sonatype_username:
         required: false
       sonatype_token:
@@ -113,6 +115,8 @@ jobs:
           (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: openrewrite/gh-automation/.github/actions/publish-snapshots@main
         with:
+          sonatype_username: ${{ secrets.sonatype_username }}
+          sonatype_token: ${{ secrets.sonatype_token }}
           ossrh_signing_key: ${{ secrets.ossrh_signing_key }}
           ossrh_signing_password: ${{ secrets.ossrh_signing_password }}
           node_auth_token: ${{ secrets.node_auth_token }}

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -107,10 +107,6 @@ jobs:
           (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: openrewrite/gh-automation/.github/actions/publish-snapshots@main
         with:
-          sonatype_username: ${{ secrets.sonatype_username }}
-          sonatype_token: ${{ secrets.sonatype_token }}
-          ossrh_signing_key: ${{ secrets.ossrh_signing_key }}
-          ossrh_signing_password: ${{ secrets.ossrh_signing_password }}
           node_auth_token: ${{ secrets.node_auth_token }}
           pypi_token: ${{ secrets.pypi_token }}
           nuget_api_key: ${{ secrets.nuget_api_key }}

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -14,7 +14,10 @@ on:
         description: Value of the Gradle Enterprise access token to use.
         required: false
 
-      # TODO Unused; remove after dropping the last caller
+      # TODO Unused by the default publishing path, but kept wired until 2026-09-08 so that an
+      # emergency release to Maven Central only costs applying the deprecated
+      # org.openrewrite.build.publish-maven-central plugin in the affected repository, rather than
+      # that plus a change here. Remove then, and remove the secrets after dropping the last caller.
       sonatype_username:
         required: false
       sonatype_token:
@@ -59,6 +62,8 @@ on:
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon --refresh-dependencies
+  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatype_username }}
+  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatype_token }}
   ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ossrh_signing_key }}
   ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ossrh_signing_password }}
   ORG_GRADLE_PROJECT_nodeAuthToken: ${{ secrets.node_auth_token }}

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -13,14 +13,17 @@ on:
       gradle_enterprise_access_key:
         description: Value of the Gradle Enterprise access token to use.
         required: false
+
+      # TODO Unused; remove after dropping the last caller
       sonatype_username:
-        required: true
+        required: false
       sonatype_token:
-        required: true
+        required: false
       ossrh_signing_key:
-        required: true
+        required: false
       ossrh_signing_password:
-        required: true
+        required: false
+
       node_auth_token:
         required: false
       pypi_token:
@@ -53,10 +56,6 @@ on:
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon --refresh-dependencies
-  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatype_username }}
-  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatype_token }}
-  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ossrh_signing_key }}
-  ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ossrh_signing_password }}
   ORG_GRADLE_PROJECT_nodeAuthToken: ${{ secrets.node_auth_token }}
   ORG_GRADLE_PROJECT_pypiToken: ${{ secrets.pypi_token }}
   ORG_GRADLE_PROJECT_nugetApiKey: ${{ secrets.nuget_api_key }}

--- a/.github/workflows/publish-gradle.yml
+++ b/.github/workflows/publish-gradle.yml
@@ -19,6 +19,9 @@ on:
         required: false
       sonatype_token:
         required: false
+
+      # TODO Still used. Drop once org.openrewrite.build.publish stops applying the signing plugin,
+      # then remove after dropping the last caller. See openrewrite/rewrite-build-gradle-plugin#220.
       ossrh_signing_key:
         required: false
       ossrh_signing_password:
@@ -56,6 +59,8 @@ on:
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon --refresh-dependencies
+  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ossrh_signing_key }}
+  ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ossrh_signing_password }}
   ORG_GRADLE_PROJECT_nodeAuthToken: ${{ secrets.node_auth_token }}
   ORG_GRADLE_PROJECT_pypiToken: ${{ secrets.pypi_token }}
   ORG_GRADLE_PROJECT_nugetApiKey: ${{ secrets.nuget_api_key }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Composite actions: individual steps shared between the workflows above (and call
 | --- | --- |
 | `setup` | Checkout with full history, install the requested JDK(s) and uv, configure Gradle with optional Develocity access. Expected to run first. |
 | `build` | Run `./gradlew build` with the standard CI switches. |
-| `publish-snapshots` | Publish snapshots with signing credentials wired in as Gradle project properties. |
+| `publish-snapshots` | Publish snapshots with the publishing credentials wired in as Gradle project properties. |
 | `slack-failure` | Post a CI failure notification to a Slack webhook; the caller supplies the `if:` guard. |
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Composite actions: individual steps shared between the workflows above (and call
 | --- | --- |
 | `setup` | Checkout with full history, install the requested JDK(s) and uv, configure Gradle with optional Develocity access. Expected to run first. |
 | `build` | Run `./gradlew build` with the standard CI switches. |
-| `publish-snapshots` | Publish snapshots with Sonatype and signing credentials wired in as Gradle project properties. |
+| `publish-snapshots` | Publish snapshots with signing credentials wired in as Gradle project properties. |
 | `slack-failure` | Post a CI failure notification to a Slack webhook; the caller supplies the `if:` guard. |
 
 ## Usage


### PR DESCRIPTION
Recipe and language libraries publish only to the Code Genome Project since [rewrite-build-gradle-plugin#220](https://github.com/openrewrite/rewrite-build-gradle-plugin/pull/220), so the Sonatype credentials no longer feed the default publishing path — but this keeps forwarding them, and the signing credentials, rather than removing either yet.

The Sonatype pair stays wired until 2026-09-08 so an emergency release to Maven Central only costs applying the deprecated `org.openrewrite.build.publish-maven-central` plugin in the affected repository; `build-root`'s no-op `closeAndReleaseSonatypeStagingRepository` stands aside when that plugin contributes the real task, so nothing else has to change to take the hatch. The signing pair stays because `RewritePublishPlugin` still signs the nebula publication and requires a signatory for every non-SNAPSHOT version. Each pair carries its own TODO naming what its removal waits on, and the four secrets are downgraded from required to optional — they stay *declared* either way, since all ~90 callers of `publish-gradle.yml` pass them explicitly and GitHub rejects a reusable workflow call that passes an undeclared secret.

The one behavioural change is dropping `-PforceSigning` from the snapshot publish, which forced signing to be *required* on SNAPSHOT versions; that is needless now that snapshots only reach CGP, and signatures are still produced whenever a key is present.